### PR TITLE
Add callr argument to BiocCheck

### DIFF
--- a/run-BiocCheck/run-bioc-check.R
+++ b/run-BiocCheck/run-bioc-check.R
@@ -27,7 +27,10 @@ args_list <- as.list(rep(TRUE, length(bioccheck_args)))
 names(args_list) <- gsub(x = bioccheck_args, pattern = "--", replacement = "", fixed = TRUE)
 
 ## run BiocCheck
-check_results <- BiocCheck::BiocCheck(package = dir, checkDir = dirname(dir), debug = FALSE, args_list)
+check_results <- do.call(BiocCheck::BiocCheck, 
+                         c(list(package = dir, checkDir = dirname(dir), 
+                                debug = FALSE, callr = FALSE), 
+                           args_list))
 
 status <- switch(error_on,
                  error = length(check_results$error),


### PR DESCRIPTION
`BiocCheck` has gained an argument `callr` from version 1.33.16 (https://github.com/Bioconductor/BiocCheck/commit/d36030c1ab647ff6e78c2921fbf72ee3a5f8197d). This caused the `run-BiocCheck` action to fail as it was assigning the provided `args_list` to the `callr` argument, and:

```
Error: Error in if (callr) { : the condition has length > 1
```

