### PR TITLE
Set `R_BIOC_VERSION` env variable used by pak

### DIFF
--- a/setup-bioc/action.yml
+++ b/setup-bioc/action.yml
@@ -27,25 +27,26 @@ runs:
       echo "::set-output name=r-version::$(echo ${RVERSION})"
       echo "::set-output name=rtools-version::$(echo ${RTOOLS})"
       echo "::set-output name=bioc-version::$(echo ${BIOCVERSION})"
+      echo "R_BIOC_VERSION=${BIOCVERSION}" >> $GITHUB_ENV
     shell: bash
-    
+
   - uses: r-lib/actions/setup-r@v2
     with:
       r-version: ${{ steps.find-versions.outputs.r-version }}
       Ncpus: ${{ inputs.Ncpus }}
       use-public-rspm: ${{ inputs.use-public-rspm }}
       rtools-version: ${{ steps.find-versions.outputs.rtools-version }}
-      
+
   - name: Download Renviron
     run: |
       download.file('https://bioconductor.org/checkResults/${{ inputs.bioc-version }}/bioc-LATEST/Renviron.bioc', destfile = '~/.Renviron', mode = 'wb')
     shell: Rscript {0}
-    
+
   - name: Setting Bioconductor mirror
     run: |
       write('options(BioC_mirror = "${{ inputs.bioc-mirror }}")', file = '~/.Rprofile', append = TRUE)
     shell: Rscript {0}
-    
+
   - name: Install and initialize BiocManager
     run: |
       install.packages(c("BiocManager", "remotes"), quiet = TRUE)


### PR DESCRIPTION
As mentioned in #6, the Bioc-version can be inconsistent with the one requested after the `setup-r-dependencies` step.  I suspect this is due to the use of  **pak** in [`setup-r-dependencies`](https://github.com/r-lib/actions/blob/v2-branch/setup-r-dependencies/action.yaml), which sets its own package repository settings (see `pak::repo_get()`) and defaults to Bioc-release, thereby ignoring the configuration done by the `setup-bioc` step.

This PR sets the environment variable [`R_BIOC_VERSION`](https://github.com/r-lib/pkgcache#package-environment-variables) environment variable during the `setup-bioc` step, to ensure that **pak** will use the requested Bioc-version in subsequent installation steps. 

See also https://github.com/r-lib/pak/issues/309#issuecomment-876202541